### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,8 @@ jobs:
   # Check that all jobs passed
   all-checks:
     name: All Checks
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [lint, test, build, cross-compile, security]
     if: always()


### PR DESCRIPTION
Potential fix for [https://github.com/gillisandrew/dragonglass-poc/security/code-scanning/8](https://github.com/gillisandrew/dragonglass-poc/security/code-scanning/8)

To fix the problem, you should add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs that lack their own block) or at each job that lacks it. Since the `all-checks` job does not need to write to the repository, the minimal permissions block should set everything to read (or even `none` if possible), but usually `contents: read` is a safe default. The recommendation is to add under the `all-checks` job definition (immediately after `name:` and before/after `runs-on:`/`needs:`) the line:

```yaml
permissions:
  contents: read
```

This ensures that the GITHUB_TOKEN is limited to only what is needed for this job and adheres to least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
